### PR TITLE
Fixing Electron Module Not Self Registering On Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,75 @@
 /build/
 /node_modules/
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+

--- a/addon.cpp
+++ b/addon.cpp
@@ -60,4 +60,4 @@ NAN_MODULE_INIT(init)
            Nan::New(static_cast<int>(IconSize::ExtraLarge)));
 }
 
-NODE_MODULE(system_icon, init);
+NODE_MODULE(system_icon, init) //DONT ADD A SEMI COLON THIS IS NOT A FUNCTION CALL IT IS A MACRO

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,26 +7,6 @@
         ],
       }],
     ],
-    'msbuild_settings': {
-      'ClCompile': {
-        'WarningLevel': 'Level3',
-        'Optimization': 'Full',
-        'FunctionLevelLinking': 'true',
-      },
-      'Lib': {
-        'LinkTimeCodeGeneration': 'true',
-      },
-    },
-    'msvs_settings': {
-      'VCCLCompilerTool': {
-        'WarningLevel': '3',
-        'Optimization': '3',
-        'EnableFunctionLevelLinking': 'true',
-      },
-      'VCLibrarianTool': {
-        'LinkTimeCodeGeneration': 'true',
-      },
-    },
     'xcode_settings': {
       'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
       'CLANG_CXX_LIBRARY': 'libc++',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,22 @@
   "requires": true,
   "dependencies": {
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "dev": true
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "os": [
     "darwin",
-    "win32"
+    "win32",
+    "linux"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,8 @@
     "url": "https://github.com/mtojo/node-system-icon/issues"
   },
   "dependencies": {
-    "bindings": "~1.3.0",
+    "bindings": "~1.5.0",
     "nan": "~2.14.0"
-  },
-  "engines": {
-    "node": ">=6.0.0"
   },
   "homepage": "https://github.com/mtojo/node-system-icon",
   "keywords": [
@@ -28,7 +25,9 @@
     "url": "https://github.com/mtojo/node-system-icon.git"
   },
   "scripts": {
-    "install": "node-gyp rebuild"
+    "install": "node-gyp rebuild",
+    "rebuild": "node-gyp rebuild",
+    "test": "node test.js"
   },
   "os": [
     "darwin",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "os": [
     "darwin",
-    "win32",
-    "linux"
+    "win32"
   ]
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+const system = require("./index");
+const {writeFileSync} = require('fs');
+
+// const {getIconForPath, ICON_SIZE_MEDIUM} = require('system-icon');
+
+
+system.getIconForPath("/Applications/Brave Browser.app", system.ICON_SIZE_MEDIUM, (err, result) => {
+    if (err) {
+        console.error(err);
+    } else {
+        writeFileSync("icon.png", result);
+    }
+});


### PR DESCRIPTION
The bindings.gyp files for Windows compiler optimizations would overwrite the node-gyp electron flags which would cause the module in electron not to self register. We just deleted the compiler optimizations and the error went away. This still works in non electron environment. 

We also added a test
```sh
npm run test
```
This test will simply execute the native node module and write an icon.png to the directory it was run in.